### PR TITLE
Fix error in ember-cli 1.13.0 and incorrect split on tagged commits (#6)

### DIFF
--- a/lib/parse-version.js
+++ b/lib/parse-version.js
@@ -9,10 +9,19 @@
  * @return {Object}
  */
 module.exports = function(version) {
-  var parts = String(version).match(/(.+)\.(\w+)$/);
+  var parts = String(version).match(/(.+)\+(\w+)$/);
 
-  return {
-    version: parts[1] || '',
-    commit: parts[2] || ''
-  };
+  if(parts === null) {
+    // tagged commit
+    return {
+      version: version,
+      commit: ''
+    }
+  }
+  else {
+    return {
+      version: parts[1] || '',
+      commit: parts[2] || ''
+    };
+  }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "git-repo-version": "^0.2.0",
+    "git-repo-version": "^0.3.0",
     "glob": "^4.0.5"
   },
   "description": "Inject build information (version, current SHA) into your Ember app.",


### PR DESCRIPTION
In ember-cli 1.13.0 ember-cli-app-version is updated to 0.4.0.
ember-cli-app-version now relies on git-repo-version 0.3.0 which changes output format. It now uses `+` to denote build specific metadata instead of `.`. This was already expected by documentation of ember-cli-build-info but not implemented.

There is one special case:
If the current commit is tagged, git-repo-version did not uses `package.json` to get the version. Instead it uses git tag directly. Also it does not append sha of a tagged commit. In these case we only have version information.

The current implementation will fail if a git tag contains a `+`. I did not see any chance to determine if the `+` is in git tag or if it denotes build specific metadata.
If we like to support git tags containing `+` we can't use `config.APP.buildInfo`.

These commit will not work with ember-cli-app-version <= 0.3.5, which is default of ember-cli < 1.13.0.
