### PR TITLE
Fix: git-repo-version has to be a dependencie to be available

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "git-repo-version": "^0.2.0",
     "glob": "^4.0.5"
   },
   "description": "Inject build information (version, current SHA) into your Ember app.",
@@ -44,5 +43,8 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "dependencies": {
+    "git-repo-version": "^0.2.0"
   }
 }


### PR DESCRIPTION
Since `devDependencies` are only available in development you get an `Error: Cannot find module 'git-repo-version'` if ember-cli-app-version is not installed (and therefore `config.APP.buildInfo` is `null`).

When merging #8 git-repo-version should be specified as `0.3.0` in this pull request.
