### PR TITLE
provide a string containing version + commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ In these case `commit` is an empty string. Otherwise it's the SHA of the current
 
 `desc` is `version` and `commit` denoted by a "+". If commit is empty `desc` is `version`.
 
+Note: If git tag names, version number in package.json or branch names contain a "+"
+this addon may behave unexpectedly.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@ Information includes:
 
 ```js
 buildInfo: {
-  version: '0.1.4', // pulled from package.json
-  commit: '53df212', // from `desc` above
+  version: '0.1.4',
+  commit: '53df212',
+  desc: '0.1.4+53df212'
 }
 ```
+
+If your app provides a version number in `package.json`, this is used as `version`.
+If not the name of current branch is used as `version`.
+If current HEAD is not a branch, the string `DETACHED_HEAD` is used.
+
+If current commit is tagged, git tag name is used as `version`.
+In these case `commit` is an empty string. Otherwise it's the SHA of the current commit. 
+
+`desc` is `version` and `commit` denoted by a "+". If commit is empty `desc` is `version`.
 
 ## Installation
 
@@ -26,6 +36,7 @@ In a template:
 ```html
 <p>Version: {{buildInfo.version}}</p>
 <p>SHA: {{buildInfo.commit}}</p>
+<p>Description: {{buildInfo.desc}}</p>
 ```
 
 In a route, controller, or service:
@@ -47,7 +58,7 @@ var app = new EmberApp({
 ### `metaTemplate`
 Allows you to inject a meta tag containing the build info. Defaults to `false`.
 
-Available template keys include `{VERSION}` and `{COMMIT}`. These keys will be replaced by the current build info values.
+Available template keys include `{VERSION}`, `{COMMIT}` and `{DESC}`. These keys will be replaced by the current build info values.
 
 The example above would yield:
 ```html

--- a/lib/build-meta-tag.js
+++ b/lib/build-meta-tag.js
@@ -17,7 +17,8 @@ module.exports = function(buildInfo, template) {
 
   var output = template
     .replace(/\{VERSION\}/gi, buildInfo.version)
-    .replace(/\{COMMIT\}/gi, buildInfo.commit);
+    .replace(/\{COMMIT\}/gi, buildInfo.commit)
+    .replace(/\{DESC\}/gi, buildInfo.desc);
 
   return '<meta name="build-info" content="' + output + '"/>';
 };

--- a/lib/parse-version.js
+++ b/lib/parse-version.js
@@ -9,10 +9,19 @@
  * @return {Object}
  */
 module.exports = function(version) {
-  var parts = String(version).match(/(.+)\.(\w+)$/);
+  var parts = String(version).match(/(.+)\+(\w+)$/);
 
-  return {
-    version: parts[1] || '',
-    commit: parts[2] || ''
-  };
+  if(parts === null) {
+    // tagged commit
+    return {
+      version: version,
+      commit: ''
+    }
+  }
+  else {
+    return {
+      version: parts[1] || '',
+      commit: parts[2] || ''
+    };
+  }
 };

--- a/lib/parse-version.js
+++ b/lib/parse-version.js
@@ -11,17 +11,22 @@
 module.exports = function(version) {
   var parts = String(version).match(/(.+)\+(\w+)$/);
 
-  if(parts === null) {
+  if(
+    parts === null ||
+    parts.length !== 3
+  ) {
     // tagged commit
     return {
       version: version,
-      commit: ''
+      commit: '',
+      desc: version
     }
   }
   else {
     return {
-      version: parts[1] || '',
-      commit: parts[2] || ''
+      version: parts[1],
+      commit: parts[2],
+      desc: parts[1] + '+' + parts[2] 
     };
   }
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "git-repo-version": "^0.2.0",
+    "git-repo-version": "^0.3.0",
     "glob": "^4.0.5"
   },
   "description": "Inject build information (version, current SHA) into your Ember app.",


### PR DESCRIPTION
 Provide `buildInfo.desc` and `{{DESC}}` again. It's `version` + `commit` following semver specification:

> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version.

Pull request #8 (Fix error in ember-cli 1.13.0 and incorrect split on tagged commits (#6)) is merged.
