### PR TITLE
Ember ~2.1 compat

### DIFF
--- a/addon/initializers/build-info.js
+++ b/addon/initializers/build-info.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export var initialize = function(container, application) {
+export var initialize = function(application) {
   var version = Ember.Object.create(application.buildInfo);
   var key = 'buildInfo';
 


### PR DESCRIPTION
Removes deprecation warning regarding initializers no longer being passed a container object, only an application argument.

/ref deprecation id: ember-application.app-initializer-initialize-argument
