### PR TITLE
Fix deprecation EMBER-APPLICATION.APP-INITIALIZER-INITIALIZE-ARGUMENTS

### DIFF
--- a/addon/initializers/build-info.js
+++ b/addon/initializers/build-info.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 
-export var initialize = function(container, application) {
-  var version = Ember.Object.create(application.buildInfo);
-  var key = 'buildInfo';
+export var initialize = function() {
+  let application = arguments[1] || arguments[0];
+  let version = Ember.Object.create(application.buildInfo);
+  let key = 'buildInfo';
 
   application.register('buildInfo:main', version, { instantiate: false, singleton: true });
   application.inject('route', key, 'buildInfo:main');


### PR DESCRIPTION
http://emberjs.com/deprecations/v2.x/#toc_initializer-arity

Replaces #16 which does not support ember 2.0 and 1.13.x.
