### PR TITLE
fixes deprecation caused by overriding options accidentally

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = {
    */
   included: function(app, parentAddon) {
     var target = (parentAddon || app);
-    this.options = mergeOptions(target);
+    this.ops = mergeOptions(target);
+    this._super.included.apply(this, arguments);
   },
 
   /**
@@ -28,7 +29,7 @@ module.exports = {
    */
   contentFor: function(type, config) {
     if (type === 'head') {
-      return buildMetaTag(config.APP.buildInfo, this.options.metaTemplate);
+      return buildMetaTag(config.APP.buildInfo, this.ops.metaTemplate);
     }
   }
 };


### PR DESCRIPTION
DEPRECATION: Ember CLI addons manage their own module transpilation during the `treeForAddon` processing. `ember-cli-build-info` (found at `/home/main/NetBeansProjects/croodle/node_modules/ember-cli-build-info`) has overridden the `this.options.babel` options which conflicts with the addons ability to transpile its `addon/` files properly. Falling back to default babel configuration options.